### PR TITLE
Update auxiliary model support

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -12,6 +12,7 @@ second_stage_load_pretrained: true # set to true if the pre-trained model is for
 load_only_params: false # set to true if do not want to load epoch numbers and optimizer parameters
 
 F0_path: "Utils/JDC/bst.t7"
+F0_config: null
 ASR_config: "Utils/ASR/config.yml"
 ASR_path: "Utils/ASR/epoch_00080.pth"
 PLBERT_dir: 'Utils/PLBERT/'

--- a/Configs/config_ft.yml
+++ b/Configs/config_ft.yml
@@ -10,6 +10,7 @@ second_stage_load_pretrained: true # set to true if the pre-trained model is for
 load_only_params: true # set to true if do not want to load epoch numbers and optimizer parameters
 
 F0_path: "Utils/JDC/bst.t7"
+F0_config: null
 ASR_config: "Utils/ASR/config.yml"
 ASR_path: "Utils/ASR/epoch_00080.pth"
 PLBERT_dir: 'Utils/PLBERT/'

--- a/Configs/config_libritts.yml
+++ b/Configs/config_libritts.yml
@@ -12,6 +12,7 @@ second_stage_load_pretrained: true # set to true if the pre-trained model is for
 load_only_params: false # set to true if do not want to load epoch numbers and optimizer parameters
 
 F0_path: "Utils/JDC/bst.t7"
+F0_config: null
 ASR_config: "Utils/ASR/config.yml"
 ASR_path: "Utils/ASR/epoch_00080.pth"
 PLBERT_dir: 'Utils/PLBERT/'

--- a/Utils/ASR/layers.py
+++ b/Utils/ASR/layers.py
@@ -1,83 +1,131 @@
-import torch
-from torch import nn
-import torch.nn.functional as F
-import torchaudio.functional as audio_F
-
 import random
+from typing import Any, Optional
+
+import torch
+import torchaudio
+import torchaudio.functional as audio_F
+import torch.nn.functional as F
+from torch import Tensor, nn
+
 random.seed(0)
 
 
 def _get_activation_fn(activ):
-    if activ == 'relu':
+    if activ == "relu":
         return nn.ReLU()
-    elif activ == 'lrelu':
+    elif activ == "lrelu":
         return nn.LeakyReLU(0.2)
-    elif activ == 'swish':
-        return lambda x: x*torch.sigmoid(x)
+    elif activ == "swish":
+        return lambda x: x * torch.sigmoid(x)
     else:
-        raise RuntimeError('Unexpected activ type %s, expected [relu, lrelu, swish]' % activ)
+        raise RuntimeError(
+            "Unexpected activ type %s, expected [relu, lrelu, swish]" % activ
+        )
+
 
 class LinearNorm(torch.nn.Module):
-    def __init__(self, in_dim, out_dim, bias=True, w_init_gain='linear'):
+    def __init__(self, in_dim, out_dim, bias=True, w_init_gain="linear"):
         super(LinearNorm, self).__init__()
         self.linear_layer = torch.nn.Linear(in_dim, out_dim, bias=bias)
 
         torch.nn.init.xavier_uniform_(
             self.linear_layer.weight,
-            gain=torch.nn.init.calculate_gain(w_init_gain))
+            gain=torch.nn.init.calculate_gain(w_init_gain),
+        )
 
     def forward(self, x):
         return self.linear_layer(x)
 
 
 class ConvNorm(torch.nn.Module):
-    def __init__(self, in_channels, out_channels, kernel_size=1, stride=1,
-                 padding=None, dilation=1, bias=True, w_init_gain='linear', param=None):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size=1,
+        stride=1,
+        padding=None,
+        dilation=1,
+        bias=True,
+        w_init_gain="linear",
+        param=None,
+    ):
         super(ConvNorm, self).__init__()
         if padding is None:
-            assert(kernel_size % 2 == 1)
+            assert kernel_size % 2 == 1
             padding = int(dilation * (kernel_size - 1) / 2)
 
-        self.conv = torch.nn.Conv1d(in_channels, out_channels,
-                                    kernel_size=kernel_size, stride=stride,
-                                    padding=padding, dilation=dilation,
-                                    bias=bias)
+        self.conv = torch.nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias,
+        )
 
         torch.nn.init.xavier_uniform_(
-            self.conv.weight, gain=torch.nn.init.calculate_gain(w_init_gain, param=param))
+            self.conv.weight,
+            gain=torch.nn.init.calculate_gain(w_init_gain, param=param),
+        )
 
     def forward(self, signal):
         conv_signal = self.conv(signal)
         return conv_signal
 
+
 class CausualConv(nn.Module):
-    def __init__(self, in_channels, out_channels, kernel_size=1, stride=1, padding=1, dilation=1, bias=True, w_init_gain='linear', param=None):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size=1,
+        stride=1,
+        padding=1,
+        dilation=1,
+        bias=True,
+        w_init_gain="linear",
+        param=None,
+    ):
         super(CausualConv, self).__init__()
         if padding is None:
-            assert(kernel_size % 2 == 1)
+            assert kernel_size % 2 == 1
             padding = int(dilation * (kernel_size - 1) / 2) * 2
         else:
             self.padding = padding * 2
-        self.conv = nn.Conv1d(in_channels, out_channels,
-                              kernel_size=kernel_size, stride=stride,
-                              padding=self.padding,
-                              dilation=dilation,
-                              bias=bias)
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=self.padding,
+            dilation=dilation,
+            bias=bias,
+        )
 
         torch.nn.init.xavier_uniform_(
-            self.conv.weight, gain=torch.nn.init.calculate_gain(w_init_gain, param=param))
+            self.conv.weight,
+            gain=torch.nn.init.calculate_gain(w_init_gain, param=param),
+        )
 
     def forward(self, x):
         x = self.conv(x)
         x = x[:, :, :-self.padding]
         return x
 
+
 class CausualBlock(nn.Module):
-    def __init__(self, hidden_dim, n_conv=3, dropout_p=0.2, activ='lrelu'):
+    def __init__(self, hidden_dim, n_conv=3, dropout_p=0.2, activ="lrelu"):
         super(CausualBlock, self).__init__()
-        self.blocks = nn.ModuleList([
-            self._get_conv(hidden_dim, dilation=3**i, activ=activ, dropout_p=dropout_p)
-            for i in range(n_conv)])
+        self.blocks = nn.ModuleList(
+            [
+                self._get_conv(
+                    hidden_dim, dilation=3 ** i, activ=activ, dropout_p=dropout_p
+                )
+                for i in range(n_conv)
+            ]
+        )
 
     def forward(self, x):
         for block in self.blocks:
@@ -86,26 +134,43 @@ class CausualBlock(nn.Module):
             x += res
         return x
 
-    def _get_conv(self, hidden_dim, dilation, activ='lrelu', dropout_p=0.2):
+    def _get_conv(self, hidden_dim, dilation, activ="lrelu", dropout_p=0.2):
         layers = [
-            CausualConv(hidden_dim, hidden_dim, kernel_size=3, padding=dilation, dilation=dilation),
+            CausualConv(
+                hidden_dim,
+                hidden_dim,
+                kernel_size=3,
+                padding=dilation,
+                dilation=dilation,
+            ),
             _get_activation_fn(activ),
             nn.BatchNorm1d(hidden_dim),
             nn.Dropout(p=dropout_p),
-            CausualConv(hidden_dim, hidden_dim, kernel_size=3, padding=1, dilation=1),
+            CausualConv(
+                hidden_dim,
+                hidden_dim,
+                kernel_size=3,
+                padding=1,
+                dilation=1,
+            ),
             _get_activation_fn(activ),
-            nn.Dropout(p=dropout_p)
+            nn.Dropout(p=dropout_p),
         ]
         return nn.Sequential(*layers)
 
+
 class ConvBlock(nn.Module):
-    def __init__(self, hidden_dim, n_conv=3, dropout_p=0.2, activ='relu'):
+    def __init__(self, hidden_dim, n_conv=3, dropout_p=0.2, activ="relu"):
         super().__init__()
         self._n_groups = 8
-        self.blocks = nn.ModuleList([
-            self._get_conv(hidden_dim, dilation=3**i, activ=activ, dropout_p=dropout_p)
-            for i in range(n_conv)])
-
+        self.blocks = nn.ModuleList(
+            [
+                self._get_conv(
+                    hidden_dim, dilation=3 ** i, activ=activ, dropout_p=dropout_p
+                )
+                for i in range(n_conv)
+            ]
+        )
 
     def forward(self, x):
         for block in self.blocks:
@@ -114,29 +179,52 @@ class ConvBlock(nn.Module):
             x += res
         return x
 
-    def _get_conv(self, hidden_dim, dilation, activ='relu', dropout_p=0.2):
+    def _get_conv(self, hidden_dim, dilation, activ="relu", dropout_p=0.2):
         layers = [
-            ConvNorm(hidden_dim, hidden_dim, kernel_size=3, padding=dilation, dilation=dilation),
+            ConvNorm(
+                hidden_dim,
+                hidden_dim,
+                kernel_size=3,
+                padding=dilation,
+                dilation=dilation,
+            ),
             _get_activation_fn(activ),
             nn.GroupNorm(num_groups=self._n_groups, num_channels=hidden_dim),
             nn.Dropout(p=dropout_p),
-            ConvNorm(hidden_dim, hidden_dim, kernel_size=3, padding=1, dilation=1),
+            ConvNorm(
+                hidden_dim,
+                hidden_dim,
+                kernel_size=3,
+                padding=1,
+                dilation=1,
+            ),
             _get_activation_fn(activ),
-            nn.Dropout(p=dropout_p)
+            nn.Dropout(p=dropout_p),
         ]
         return nn.Sequential(*layers)
 
+
 class LocationLayer(nn.Module):
-    def __init__(self, attention_n_filters, attention_kernel_size,
-                 attention_dim):
+    def __init__(
+        self,
+        attention_n_filters,
+        attention_kernel_size,
+        attention_dim,
+    ):
         super(LocationLayer, self).__init__()
         padding = int((attention_kernel_size - 1) / 2)
-        self.location_conv = ConvNorm(2, attention_n_filters,
-                                      kernel_size=attention_kernel_size,
-                                      padding=padding, bias=False, stride=1,
-                                      dilation=1)
-        self.location_dense = LinearNorm(attention_n_filters, attention_dim,
-                                         bias=False, w_init_gain='tanh')
+        self.location_conv = ConvNorm(
+            2,
+            attention_n_filters,
+            kernel_size=attention_kernel_size,
+            padding=padding,
+            bias=False,
+            stride=1,
+            dilation=1,
+        )
+        self.location_dense = LinearNorm(
+            attention_n_filters, attention_dim, bias=False, w_init_gain="tanh"
+        )
 
     def forward(self, attention_weights_cat):
         processed_attention = self.location_conv(attention_weights_cat)
@@ -146,21 +234,37 @@ class LocationLayer(nn.Module):
 
 
 class Attention(nn.Module):
-    def __init__(self, attention_rnn_dim, embedding_dim, attention_dim,
-                 attention_location_n_filters, attention_location_kernel_size):
+    def __init__(
+        self,
+        attention_rnn_dim,
+        embedding_dim,
+        attention_dim,
+        attention_location_n_filters,
+        attention_location_kernel_size,
+        attention_dropout=0.0,
+    ):
         super(Attention, self).__init__()
-        self.query_layer = LinearNorm(attention_rnn_dim, attention_dim,
-                                      bias=False, w_init_gain='tanh')
-        self.memory_layer = LinearNorm(embedding_dim, attention_dim, bias=False,
-                                       w_init_gain='tanh')
+        self.query_layer = LinearNorm(
+            attention_rnn_dim, attention_dim, bias=False, w_init_gain="tanh"
+        )
+        self.memory_layer = LinearNorm(
+            embedding_dim, attention_dim, bias=False, w_init_gain="tanh"
+        )
         self.v = LinearNorm(attention_dim, 1, bias=False)
-        self.location_layer = LocationLayer(attention_location_n_filters,
-                                            attention_location_kernel_size,
-                                            attention_dim)
+        self.location_layer = LocationLayer(
+            attention_location_n_filters, attention_location_kernel_size, attention_dim
+        )
         self.score_mask_value = -float("inf")
+        self.attention_dropout_p = max(0.0, float(attention_dropout))
+        self._attention_dropout = (
+            nn.Dropout(p=self.attention_dropout_p)
+            if self.attention_dropout_p > 0.0
+            else None
+        )
 
-    def get_alignment_energies(self, query, processed_memory,
-                               attention_weights_cat):
+    def get_alignment_energies(
+        self, query, processed_memory, attention_weights_cat
+    ):
         """
         PARAMS
         ------
@@ -174,14 +278,23 @@ class Attention(nn.Module):
 
         processed_query = self.query_layer(query.unsqueeze(1))
         processed_attention_weights = self.location_layer(attention_weights_cat)
-        energies = self.v(torch.tanh(
-            processed_query + processed_attention_weights + processed_memory))
+        energies = self.v(
+            torch.tanh(
+                processed_query + processed_attention_weights + processed_memory
+            )
+        )
 
         energies = energies.squeeze(-1)
         return energies
 
-    def forward(self, attention_hidden_state, memory, processed_memory,
-                attention_weights_cat, mask):
+    def forward(
+        self,
+        attention_hidden_state,
+        memory,
+        processed_memory,
+        attention_weights_cat,
+        mask,
+    ):
         """
         PARAMS
         ------
@@ -191,99 +304,25 @@ class Attention(nn.Module):
         attention_weights_cat: previous and cummulative attention weights
         mask: binary mask for padded data
         """
+
         alignment = self.get_alignment_energies(
-            attention_hidden_state, processed_memory, attention_weights_cat)
+            attention_hidden_state, processed_memory, attention_weights_cat
+        )
 
         if mask is not None:
             alignment.data.masked_fill_(mask, self.score_mask_value)
 
         attention_weights = F.softmax(alignment, dim=1)
+
+        if self._attention_dropout is not None and self.attention_dropout_p > 0.0:
+            attention_weights = self._attention_dropout(attention_weights)
+            denom = attention_weights.sum(dim=1, keepdim=True).clamp_min(1.0e-8)
+            attention_weights = attention_weights / denom
+
         attention_context = torch.bmm(attention_weights.unsqueeze(1), memory)
         attention_context = attention_context.squeeze(1)
 
         return attention_context, attention_weights
-
-
-class ForwardAttentionV2(nn.Module):
-    def __init__(self, attention_rnn_dim, embedding_dim, attention_dim,
-                 attention_location_n_filters, attention_location_kernel_size):
-        super(ForwardAttentionV2, self).__init__()
-        self.query_layer = LinearNorm(attention_rnn_dim, attention_dim,
-                                      bias=False, w_init_gain='tanh')
-        self.memory_layer = LinearNorm(embedding_dim, attention_dim, bias=False,
-                                       w_init_gain='tanh')
-        self.v = LinearNorm(attention_dim, 1, bias=False)
-        self.location_layer = LocationLayer(attention_location_n_filters,
-                                            attention_location_kernel_size,
-                                            attention_dim)
-        self.score_mask_value = -float(1e20)
-
-    def get_alignment_energies(self, query, processed_memory,
-                               attention_weights_cat):
-        """
-        PARAMS
-        ------
-        query: decoder output (batch, n_mel_channels * n_frames_per_step)
-        processed_memory: processed encoder outputs (B, T_in, attention_dim)
-        attention_weights_cat:  prev. and cumulative att weights (B, 2, max_time)
-        RETURNS
-        -------
-        alignment (batch, max_time)
-        """
-
-        processed_query = self.query_layer(query.unsqueeze(1))
-        processed_attention_weights = self.location_layer(attention_weights_cat)
-        energies = self.v(torch.tanh(
-            processed_query + processed_attention_weights + processed_memory))
-
-        energies = energies.squeeze(-1)
-        return energies
-
-    def forward(self, attention_hidden_state, memory, processed_memory,
-                attention_weights_cat, mask, log_alpha):
-        """
-        PARAMS
-        ------
-        attention_hidden_state: attention rnn last output
-        memory: encoder outputs
-        processed_memory: processed encoder outputs
-        attention_weights_cat: previous and cummulative attention weights
-        mask: binary mask for padded data
-        """
-        log_energy = self.get_alignment_energies(
-            attention_hidden_state, processed_memory, attention_weights_cat)
-
-        #log_energy =
-
-        if mask is not None:
-            log_energy.data.masked_fill_(mask, self.score_mask_value)
-
-        #attention_weights = F.softmax(alignment, dim=1)
-
-        #content_score = log_energy.unsqueeze(1) #[B, MAX_TIME] -> [B, 1, MAX_TIME]
-        #log_alpha = log_alpha.unsqueeze(2) #[B, MAX_TIME] -> [B, MAX_TIME, 1]
-
-        #log_total_score = log_alpha + content_score
-
-        #previous_attention_weights = attention_weights_cat[:,0,:]
-
-        log_alpha_shift_padded = []
-        max_time = log_energy.size(1)
-        for sft in range(2):
-            shifted = log_alpha[:,:max_time-sft]
-            shift_padded = F.pad(shifted, (sft,0), 'constant', self.score_mask_value)
-            log_alpha_shift_padded.append(shift_padded.unsqueeze(2))
-
-        biased = torch.logsumexp(torch.cat(log_alpha_shift_padded,2), 2)
-
-        log_alpha_new = biased +  log_energy
-
-        attention_weights =  F.softmax(log_alpha_new, dim=1)
-
-        attention_context = torch.bmm(attention_weights.unsqueeze(1), memory)
-        attention_context = attention_context.squeeze(1)
-
-        return attention_context, attention_weights, log_alpha_new
 
 
 class PhaseShuffle2d(nn.Module):
@@ -305,6 +344,7 @@ class PhaseShuffle2d(nn.Module):
             shuffled = torch.cat([right, left], dim=3)
         return shuffled
 
+
 class PhaseShuffle1d(nn.Module):
     def __init__(self, n=2):
         super(PhaseShuffle1d, self).__init__()
@@ -319,20 +359,21 @@ class PhaseShuffle1d(nn.Module):
         if move == 0:
             return x
         else:
-            left = x[:, :,  :move]
+            left = x[:, :, :move]
             right = x[:, :, move:]
             shuffled = torch.cat([right, left], dim=2)
 
         return shuffled
+
 
 class MFCC(nn.Module):
     def __init__(self, n_mfcc=40, n_mels=80):
         super(MFCC, self).__init__()
         self.n_mfcc = n_mfcc
         self.n_mels = n_mels
-        self.norm = 'ortho'
+        self.norm = "ortho"
         dct_mat = audio_F.create_dct(self.n_mfcc, self.n_mels, self.norm)
-        self.register_buffer('dct_mat', dct_mat)
+        self.register_buffer("dct_mat", dct_mat)
 
     def forward(self, mel_specgram):
         if len(mel_specgram.shape) == 2:
@@ -348,3 +389,40 @@ class MFCC(nn.Module):
         if unsqueezed:
             mfcc = mfcc.squeeze(0)
         return mfcc
+
+
+class MelSpectrogram(nn.Module):
+    def __init__(
+        self,
+        sample_rate,
+        n_fft,
+        win_length,
+        hop_length,
+        f_min,
+        f_max,
+        n_mels,
+        power=1,
+        center=False,
+    ):
+        super(MelSpectrogram, self).__init__()
+        melkwargs: Optional[dict[str, Any]] = {
+            "n_fft": n_fft,
+            "win_length": win_length,
+            "hop_length": hop_length,
+            "f_min": f_min,
+            "f_max": f_max,
+            "pad": 0,
+            "n_mels": n_mels,
+            "window_fn": torch.hann_window,
+            "power": power,
+            "normalized": False,
+            "wkwargs": None,
+            "center": center,
+        }
+
+        self.mel_ = torchaudio.transforms.MelSpectrogram(
+            sample_rate, **melkwargs
+        )
+
+    def forward(self, y: Tensor) -> Tensor:
+        return self.mel_(y)

--- a/Utils/ASR/models.py
+++ b/Utils/ASR/models.py
@@ -1,61 +1,729 @@
 import math
+from typing import Dict, List, Optional, Tuple
+
 import torch
-from torch import nn
 import torch.nn.functional as F
+from torch import nn
+from torch.utils.checkpoint import checkpoint, checkpoint_sequential
+
 from .layers import MFCC, Attention, LinearNorm, ConvNorm, ConvBlock
 
-class ASRCNN(nn.Module):
-    def __init__(self,
-                 input_dim=80,
-                 hidden_dim=256,
-                 n_token=35,
-                 n_layers=6,
-                 token_embedding_dim=256,
 
+def _stochastic_depth(residual: torch.Tensor, drop_prob: float, training: bool) -> torch.Tensor:
+    """Apply sample-wise stochastic depth to a residual branch."""
+
+    if drop_prob <= 0.0 or not training:
+        return residual
+
+    keep_prob = 1.0 - drop_prob
+    if keep_prob <= 0.0:
+        return torch.zeros_like(residual)
+
+    shape = (residual.size(0),) + (1,) * (residual.dim() - 1)
+    random_tensor = keep_prob + torch.rand(shape, dtype=residual.dtype, device=residual.device)
+    random_tensor.floor_()
+    return residual / keep_prob * random_tensor
+
+
+class EncoderStage(nn.Module):
+    """A convolutional encoder stage with optional stochastic depth."""
+
+    def __init__(self, hidden_dim: int, drop_prob: float = 0.0):
+        super().__init__()
+        self.drop_prob = float(max(0.0, drop_prob))
+        self.block = ConvBlock(hidden_dim)
+        self.post_norm = nn.GroupNorm(num_groups=1, num_channels=hidden_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = self.block(x)
+        residual = self.post_norm(residual)
+
+        if self.drop_prob > 0.0:
+            delta = residual - x
+            delta = _stochastic_depth(delta, self.drop_prob, self.training)
+            residual = x + delta
+
+        return residual
+
+
+class IntermediateCTCHead(nn.Module):
+    """Light-weight projection head for intermediate CTC supervision."""
+
+    def __init__(self, hidden_dim: int, n_token: int, dropout: float = 0.1):
+        super().__init__()
+        projection_dim = max(1, hidden_dim // 2)
+        self.layers = nn.Sequential(
+            ConvNorm(hidden_dim, projection_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            ConvNorm(projection_dim, n_token),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        logits = self.layers(x)
+        return logits.transpose(1, 2)
+
+
+class SelfConditionedCTCBlock(nn.Module):
+    """Predicts self-conditioned CTC distributions and feeds them back to the encoder."""
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        n_token: int,
+        strategy: str = "add",
+        detach_conditioning: bool = True,
+        temperature: float = 1.0,
+        predictor_dropout: float = 0.1,
+        fusion_dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.strategy = str(strategy).lower()
+        if self.strategy not in {"add", "concat"}:
+            raise ValueError(f"Unsupported self-conditioned strategy: {self.strategy}")
+
+        self.detach_conditioning = bool(detach_conditioning)
+        self.temperature = max(1e-5, float(temperature))
+
+        projection_dim = max(1, hidden_dim // 2)
+        self.predictor = nn.Sequential(
+            ConvNorm(hidden_dim, hidden_dim, kernel_size=1),
+            nn.GELU(),
+            nn.Dropout(predictor_dropout),
+            ConvNorm(hidden_dim, projection_dim, kernel_size=1),
+            nn.GELU(),
+            nn.Dropout(predictor_dropout),
+            ConvNorm(projection_dim, n_token, kernel_size=1),
+        )
+
+        self.condition_projector = nn.Sequential(
+            nn.Dropout(predictor_dropout),
+            ConvNorm(n_token, hidden_dim, kernel_size=1),
+        )
+
+        if self.strategy == "concat":
+            self.fusion = nn.Sequential(
+                nn.Dropout(fusion_dropout),
+                ConvNorm(hidden_dim * 2, hidden_dim, kernel_size=1),
+                nn.GELU(),
+            )
+        else:
+            self.fusion = None
+
+    def forward(self, features: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Return conditioned features along with logits and log-probabilities."""
+
+        logits = self.predictor(features)
+        scaled_logits = logits / self.temperature
+        log_probs = F.log_softmax(scaled_logits, dim=1)
+        probs = log_probs.exp()
+
+        conditioning_source = probs.detach() if self.detach_conditioning else probs
+        conditioning = self.condition_projector(conditioning_source)
+
+        if self.strategy == "concat" and self.fusion is not None:
+            fused = torch.cat([features, conditioning], dim=1)
+            conditioned_features = self.fusion(fused)
+        else:
+            conditioned_features = features + conditioning
+
+        return {
+            "features": conditioned_features,
+            "logits": logits.transpose(1, 2),
+            "log_probs": log_probs.transpose(1, 2),
+        }
+
+
+def build_model(model_params={}, model_type="asr"):
+    model = ASRCNN(**model_params)
+    return model
+
+
+class ASRCNN(nn.Module):
+    def __init__(
+        self,
+        input_dim=80,
+        hidden_dim=256,
+        n_token=35,
+        n_layers=6,
+        token_embedding_dim=256,
+        location_kernel_size=63,
+        attention_dropout=0.0,
+        multi_task_config=None,
+        stabilization_config=None,
+        memory_optimization_config=None,
     ):
         super().__init__()
         self.n_token = n_token
         self.n_down = 1
         self.to_mfcc = MFCC()
-        self.init_cnn = ConvNorm(input_dim//2, hidden_dim, kernel_size=7, padding=3, stride=2)
-        self.cnns = nn.Sequential(
-            *[nn.Sequential(
-                ConvBlock(hidden_dim),
-                nn.GroupNorm(num_groups=1, num_channels=hidden_dim)
-            ) for n in range(n_layers)])
+        self.init_cnn = ConvNorm(
+            input_dim // 2, hidden_dim, kernel_size=7, padding=3, stride=2
+        )
+        self.stabilization_config = stabilization_config or {}
+        self._stochastic_depth_cfg = (
+            self.stabilization_config.get("stochastic_depth", {}) or {}
+        )
+        self.enable_stochastic_depth = bool(
+            self._stochastic_depth_cfg.get("enabled", False)
+        )
+        self.memory_optimization_config = memory_optimization_config or {}
+        self._gradient_checkpoint_cfg = (
+            self.memory_optimization_config.get("gradient_checkpointing", {}) or {}
+        )
+        self.enable_gradient_checkpointing = bool(
+            self._gradient_checkpoint_cfg.get("enabled", False)
+        )
+
+        def _safe_int(value, default):
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+
+        self.gradient_checkpoint_start_layer = max(
+            1, _safe_int(self._gradient_checkpoint_cfg.get("start_layer", 1), 1)
+        )
+        end_layer = self._gradient_checkpoint_cfg.get("end_layer", None)
+        parsed_end = None if end_layer in (None, "", "none", "null") else _safe_int(end_layer, None)
+        if isinstance(parsed_end, int) and parsed_end <= 0:
+            parsed_end = None
+        if isinstance(parsed_end, int):
+            parsed_end = max(
+                self.gradient_checkpoint_start_layer, min(n_layers, parsed_end)
+            )
+        self.gradient_checkpoint_end_layer: Optional[int] = parsed_end
+        segments = _safe_int(self._gradient_checkpoint_cfg.get("segments", 1), 1)
+        self.gradient_checkpoint_segments = max(1, segments)
+        chunk_size = _safe_int(self._gradient_checkpoint_cfg.get("chunk_size", 0), 0)
+        self.gradient_checkpoint_chunk_size = max(0, chunk_size)
+        min_seq_len = _safe_int(
+            self._gradient_checkpoint_cfg.get("min_sequence_length", 0), 0
+        )
+        self.gradient_checkpoint_min_seq_len = max(0, min_seq_len)
+        self.gradient_checkpoint_use_sequential = bool(
+            self._gradient_checkpoint_cfg.get("use_checkpoint_sequential", True)
+        )
+        self.gradient_checkpoint_use_reentrant = bool(
+            self._gradient_checkpoint_cfg.get("use_reentrant", False)
+        )
+
+        self.encoder_layers = nn.ModuleList()
+        for layer_idx in range(1, n_layers + 1):
+            if self.enable_stochastic_depth:
+                drop_prob = self._get_stochastic_depth_prob(layer_idx, n_layers)
+            else:
+                drop_prob = 0.0
+            self.encoder_layers.append(EncoderStage(hidden_dim, drop_prob=drop_prob))
+
+        ictc_cfg = self.stabilization_config.get("intermediate_ctc", {}) or {}
+        self.enable_intermediate_ctc = bool(ictc_cfg.get("enabled", False))
+        ictc_dropout = float(ictc_cfg.get("dropout", 0.1))
+        self.intermediate_ctc_layers = self._parse_intermediate_layers(
+            ictc_cfg.get("layers"), n_layers
+        )
+        if self.enable_intermediate_ctc and self.intermediate_ctc_layers:
+            self.intermediate_ctc_heads = nn.ModuleDict(
+                {
+                    str(layer_idx): IntermediateCTCHead(
+                        hidden_dim, n_token, dropout=ictc_dropout
+                    )
+                    for layer_idx in self.intermediate_ctc_layers
+                }
+            )
+        else:
+            self.intermediate_ctc_heads = nn.ModuleDict()
+
+        sctc_cfg = self.stabilization_config.get("self_conditioned_ctc", {}) or {}
+        self.enable_self_conditioned_ctc = bool(sctc_cfg.get("enabled", False))
+        self.self_conditioning_layers = self._parse_intermediate_layers(
+            sctc_cfg.get("layers"), n_layers
+        )
+        if self.enable_self_conditioned_ctc and self.self_conditioning_layers:
+            self.self_conditioning_blocks = nn.ModuleDict(
+                {
+                    str(layer_idx): SelfConditionedCTCBlock(
+                        hidden_dim=hidden_dim,
+                        n_token=n_token,
+                        strategy=sctc_cfg.get("conditioning_strategy", "add"),
+                        detach_conditioning=sctc_cfg.get(
+                            "detach_conditioning", True
+                        ),
+                        temperature=sctc_cfg.get("temperature", 1.0),
+                        predictor_dropout=sctc_cfg.get("predictor_dropout", 0.1),
+                        fusion_dropout=sctc_cfg.get("fusion_dropout", 0.1),
+                    )
+                    for layer_idx in self.self_conditioning_layers
+                }
+            )
+        else:
+            self.self_conditioning_blocks = nn.ModuleDict()
+
+        self._checkpoint_special_layers = set(self.intermediate_ctc_layers)
+        self._checkpoint_special_layers.update(self.self_conditioning_layers)
+
         self.projection = ConvNorm(hidden_dim, hidden_dim // 2)
-        self.ctc_linear = nn.Sequential(
-            LinearNorm(hidden_dim//2, hidden_dim),
-            nn.ReLU(),
-            LinearNorm(hidden_dim, n_token))
+        self.multi_task_config = multi_task_config or {}
+        self.use_ctc = bool(self.multi_task_config.get("use_ctc", True))
+        self.use_seq2seq = bool(self.multi_task_config.get("use_seq2seq", True))
+
+        head_sharing_cfg = (self.multi_task_config.get("head_sharing", {}) or {})
+        ctc_seq2seq_cfg = (head_sharing_cfg.get("ctc_seq2seq", {}) or {})
+        self.enable_ctc_seq2seq_sharing = bool(
+            ctc_seq2seq_cfg.get("enabled", False) and self.use_ctc and self.use_seq2seq
+        )
+        self.ctc_seq2seq_detach = bool(
+            ctc_seq2seq_cfg.get("detach_for_seq2seq", False)
+        )
+
+        self.ctc_state_projector: Optional[nn.Module] = None
+        self.ctc_state_activation: Optional[nn.Module] = None
+        self.ctc_classifier: Optional[nn.Module] = None
+        self.ctc_seq2seq_adapter: Optional[nn.Module] = None
+
+        if self.use_ctc:
+            if self.enable_ctc_seq2seq_sharing:
+                self.ctc_state_projector = LinearNorm(hidden_dim // 2, hidden_dim)
+                self.ctc_state_activation = nn.ReLU()
+                self.ctc_classifier = LinearNorm(hidden_dim, n_token)
+                self.ctc_seq2seq_adapter = LinearNorm(hidden_dim, hidden_dim // 2)
+                self.ctc_linear = None
+            else:
+                self.ctc_linear = nn.Sequential(
+                    LinearNorm(hidden_dim // 2, hidden_dim),
+                    nn.ReLU(),
+                    LinearNorm(hidden_dim, n_token),
+                )
+        else:
+            self.ctc_linear = None
+
         self.asr_s2s = ASRS2S(
             embedding_dim=token_embedding_dim,
-            hidden_dim=hidden_dim//2,
-            n_token=n_token)
+            hidden_dim=hidden_dim // 2,
+            n_token=n_token,
+            location_kernel_size=location_kernel_size,
+            attention_dropout=attention_dropout,
+        )
+
+        duration_hidden = max(4, hidden_dim // 16)
+        self.duration_predictor = nn.Sequential(
+            nn.Embedding(n_token, duration_hidden),
+            nn.ReLU(),
+            nn.Linear(duration_hidden, 1),
+            nn.Softplus(),
+        )
+
+        frame_cfg = self.multi_task_config.get("frame_phoneme", {}) or {}
+        self.enable_frame_classifier = bool(frame_cfg.get("enabled", False))
+        if self.enable_frame_classifier:
+            n_classes = int(frame_cfg.get("num_classes") or 0)
+            if n_classes <= 0:
+                n_classes = n_token
+            self.frame_classifier = nn.Sequential(
+                LinearNorm(hidden_dim // 2, hidden_dim // 2),
+                nn.ReLU(),
+                LinearNorm(hidden_dim // 2, n_classes),
+            )
+            self.frame_num_classes = n_classes
+        else:
+            self.frame_classifier = None
+            self.frame_num_classes = 0
+
+        speaker_cfg = self.multi_task_config.get("speaker", {}) or {}
+        self.enable_speaker = bool(speaker_cfg.get("enabled", False))
+        if self.enable_speaker:
+            embedding_dim = int(speaker_cfg.get("embedding_dim", hidden_dim // 2))
+            self.num_speakers = max(1, int(speaker_cfg.get("num_speakers", 1)))
+            self.speaker_projection = nn.Linear(hidden_dim // 2, embedding_dim)
+            self.speaker_norm = nn.LayerNorm(embedding_dim)
+            self.speaker_classifier = nn.Linear(embedding_dim, self.num_speakers)
+        else:
+            self.speaker_projection = None
+            self.speaker_classifier = None
+            self.speaker_norm = None
+            self.num_speakers = 0
+
+        pron_cfg = self.multi_task_config.get("pronunciation_error", {}) or {}
+        self.enable_pronunciation_error = bool(pron_cfg.get("enabled", False))
+        if self.enable_pronunciation_error:
+            num_classes = max(2, int(pron_cfg.get("num_classes", 2)))
+            self.pron_error_head = nn.Sequential(
+                LinearNorm(self.asr_s2s.decoder_rnn_dim, hidden_dim // 2),
+                nn.ReLU(),
+                LinearNorm(hidden_dim // 2, num_classes),
+            )
+            self.pron_error_num_classes = num_classes
+        else:
+            self.pron_error_head = None
+            self.pron_error_num_classes = 0
+
+    def _get_stochastic_depth_prob(self, layer_idx: int, total_layers: int) -> float:
+        strategy = str(self._stochastic_depth_cfg.get("mode", "linear")).lower()
+        min_drop = float(self._stochastic_depth_cfg.get("min_drop_rate", 0.0))
+        max_drop = float(
+            self._stochastic_depth_cfg.get("max_drop_rate", self._stochastic_depth_cfg.get("drop_rate", 0.0))
+        )
+        max_drop = max(0.0, min(1.0, max_drop))
+        min_drop = max(0.0, min(1.0, min_drop))
+        if total_layers <= 1:
+            return max_drop
+
+        if strategy == "uniform":
+            return max_drop
+
+        progress = (layer_idx - 1) / (total_layers - 1)
+        drop = min_drop + (max_drop - min_drop) * progress
+        return max(0.0, min(1.0, drop))
+
+    @staticmethod
+    def _parse_intermediate_layers(layers_config, max_layers: int) -> List[int]:
+        if layers_config is None:
+            return []
+
+        parsed: List[int] = []
+        if isinstance(layers_config, dict):
+            source = layers_config.keys()
+        else:
+            source = layers_config
+
+        for entry in source:
+            if isinstance(entry, dict):
+                idx = entry.get("index", entry.get("layer"))
+            else:
+                idx = entry
+            try:
+                value = int(idx)
+            except (TypeError, ValueError):
+                continue
+            if 1 <= value <= max_layers:
+                parsed.append(value)
+
+        # Preserve ordering but drop duplicates
+        seen = set()
+        ordered: List[int] = []
+        for value in parsed:
+            if value not in seen:
+                seen.add(value)
+                ordered.append(value)
+        return ordered
 
     def forward(self, x, src_key_padding_mask=None, text_input=None):
         x = self.to_mfcc(x)
         x = self.init_cnn(x)
-        x = self.cnns(x)
+        intermediate_outputs: Dict[str, torch.Tensor] = {}
+        self_conditioned_outputs: Dict[str, torch.Tensor] = {}
+        self_conditioned_log_probs: Dict[str, torch.Tensor] = {}
+
+        chunk: List[Tuple[int, nn.Module]] = []
+
+        def _flush_chunk() -> Optional[int]:
+            nonlocal x, chunk
+            if not chunk:
+                return None
+
+            modules = [module for _, module in chunk]
+            segments = min(len(modules), self.gradient_checkpoint_segments)
+            segments = max(1, segments)
+
+            if self.gradient_checkpoint_use_sequential or len(modules) > 1:
+                try:
+                    x = checkpoint_sequential(
+                        modules,
+                        segments,
+                        x,
+                        use_reentrant=self.gradient_checkpoint_use_reentrant,
+                    )
+                except TypeError:
+                    x = checkpoint_sequential(modules, segments, x)
+            else:
+                def _run_modules(inp: torch.Tensor) -> torch.Tensor:
+                    for module in modules:
+                        inp = module(inp)
+                    return inp
+
+                try:
+                    x = checkpoint(
+                        _run_modules,
+                        x,
+                        use_reentrant=self.gradient_checkpoint_use_reentrant,
+                    )
+                except TypeError:
+                    x = checkpoint(_run_modules, x)
+
+            last_idx = chunk[-1][0]
+            chunk = []
+            return last_idx
+
+        def _process_layer_outputs(layer_idx: int) -> None:
+            nonlocal x
+            key = str(layer_idx)
+            if key in self.intermediate_ctc_heads:
+                intermediate_outputs[key] = self.intermediate_ctc_heads[key](x)
+            if key in self.self_conditioning_blocks:
+                conditioning = self.self_conditioning_blocks[key](x)
+                x = conditioning["features"]
+                self_conditioned_outputs[key] = conditioning["logits"]
+                self_conditioned_log_probs[key] = conditioning["log_probs"]
+
+        for layer_idx, layer in enumerate(self.encoder_layers, start=1):
+            if self._should_checkpoint_layer(layer_idx, x):
+                chunk.append((layer_idx, layer))
+                is_special = layer_idx in self._checkpoint_special_layers
+                chunk_full = (
+                    self.gradient_checkpoint_chunk_size > 0
+                    and len(chunk) >= self.gradient_checkpoint_chunk_size
+                )
+                if is_special or chunk_full:
+                    flushed = _flush_chunk()
+                    if flushed is not None:
+                        _process_layer_outputs(flushed)
+                continue
+
+            flushed = _flush_chunk()
+            if flushed is not None:
+                _process_layer_outputs(flushed)
+
+            x = layer(x)
+            _process_layer_outputs(layer_idx)
+
+        flushed = _flush_chunk()
+        if flushed is not None:
+            _process_layer_outputs(flushed)
+
         x = self.projection(x)
         x = x.transpose(1, 2)
-        ctc_logit = self.ctc_linear(x)
+        raw_encoder_features = x
+        decoder_memory = x
+        shared_states: Optional[torch.Tensor] = None
+        outputs: Dict[str, torch.Tensor] = {}
+
+        if intermediate_outputs:
+            outputs["intermediate_ctc_logits"] = intermediate_outputs
+
+        if self_conditioned_outputs:
+            outputs["self_conditioned_ctc_logits"] = self_conditioned_outputs
+            outputs["self_conditioned_ctc_log_probs"] = self_conditioned_log_probs
+
+        if self.enable_ctc_seq2seq_sharing and self.ctc_state_projector is not None:
+            shared_states = self.ctc_state_projector(decoder_memory)
+            if self.ctc_state_activation is not None:
+                shared_states = self.ctc_state_activation(shared_states)
+            if self.use_ctc and self.ctc_classifier is not None:
+                ctc_logit = self.ctc_classifier(shared_states)
+                outputs["ctc_logits"] = ctc_logit
+            if self.use_seq2seq and self.ctc_seq2seq_adapter is not None:
+                adapter_input = (
+                    shared_states.detach()
+                    if self.ctc_seq2seq_detach
+                    else shared_states
+                )
+                decoder_memory = self.ctc_seq2seq_adapter(adapter_input)
+        elif self.use_ctc and self.ctc_linear is not None:
+            ctc_logit = self.ctc_linear(decoder_memory)
+            outputs["ctc_logits"] = ctc_logit
+
+        if "logits_ctc" not in outputs and isinstance(outputs.get("ctc_logits"), torch.Tensor):
+            outputs["logits_ctc"] = outputs["ctc_logits"]
+
+        outputs["encoder_features"] = decoder_memory
+        if shared_states is not None:
+            outputs["ctc_seq2seq_shared_states"] = shared_states
+            outputs["raw_encoder_features"] = raw_encoder_features
+
+        if self.enable_frame_classifier and self.frame_classifier is not None:
+            frame_logits = self.frame_classifier(decoder_memory)
+            outputs["frame_phoneme_logits"] = frame_logits
+
+        if self.enable_speaker and self.speaker_projection is not None:
+            pooled = decoder_memory.mean(dim=1)
+            speaker_embedding = torch.tanh(self.speaker_projection(pooled))
+            speaker_embedding = self.speaker_norm(speaker_embedding)
+            speaker_logits = self.speaker_classifier(speaker_embedding)
+            outputs["speaker_embeddings"] = speaker_embedding
+            outputs["speaker_logits"] = speaker_logits
+
         if text_input is not None:
-            _, s2s_logit, s2s_attn = self.asr_s2s(x, src_key_padding_mask, text_input)
-            return ctc_logit, s2s_logit, s2s_attn
+            duration_prediction = self.duration_predictor(text_input.long())
+            outputs["duration_predictions"] = duration_prediction
+
+        if text_input is not None and self.use_seq2seq:
+            hidden_outputs, s2s_logit, s2s_attn = self.asr_s2s(
+                decoder_memory, src_key_padding_mask, text_input
+            )
+            outputs["s2s_hidden"] = hidden_outputs
+            outputs["s2s_logits"] = s2s_logit
+            outputs["s2s_attn"] = s2s_attn
+
+            if self.enable_pronunciation_error and self.pron_error_head is not None:
+                # remove the initial SOS step when computing pronunciation error logits
+                if hidden_outputs.size(1) > 1:
+                    pron_input = hidden_outputs[:, 1:, :]
+                else:
+                    pron_input = hidden_outputs
+                pron_error_logits = self.pron_error_head(pron_input)
+                outputs["pron_error_logits"] = pron_error_logits
+        elif text_input is None:
+            outputs.setdefault("s2s_logits", None)
+
+        if "primary_logits" not in outputs:
+            if isinstance(outputs.get("ctc_logits"), torch.Tensor):
+                outputs["primary_logits"] = outputs["ctc_logits"]
+            elif isinstance(outputs.get("s2s_logits"), torch.Tensor):
+                outputs["primary_logits"] = outputs["s2s_logits"]
+
+        return outputs
+
+    def _should_checkpoint_layer(self, layer_idx: int, tensor: torch.Tensor) -> bool:
+        if not self.enable_gradient_checkpointing:
+            return False
+        if not self.training:
+            return False
+        if not isinstance(tensor, torch.Tensor) or not tensor.requires_grad:
+            return False
+        if (
+            self.gradient_checkpoint_min_seq_len > 0
+            and tensor.size(-1) < self.gradient_checkpoint_min_seq_len
+        ):
+            return False
+        if layer_idx < self.gradient_checkpoint_start_layer:
+            return False
+        end_layer = self.gradient_checkpoint_end_layer or len(self.encoder_layers)
+        if layer_idx > end_layer:
+            return False
+        return True
+
+    def _optional_state_prefixes(self):
+        prefixes = []
+        if not self.use_ctc:
+            prefixes.extend(
+                [
+                    "ctc_linear",
+                    "ctc_state_projector",
+                    "ctc_classifier",
+                    "ctc_seq2seq_adapter",
+                ]
+            )
         else:
-            return ctc_logit
+            if self.ctc_linear is None:
+                prefixes.append("ctc_linear")
+            if not self.enable_ctc_seq2seq_sharing:
+                prefixes.extend(
+                    [
+                        "ctc_state_projector",
+                        "ctc_classifier",
+                        "ctc_seq2seq_adapter",
+                    ]
+                )
+        if not self.enable_frame_classifier or self.frame_classifier is None:
+            prefixes.append("frame_classifier")
+        if not self.enable_speaker or self.speaker_projection is None:
+            prefixes.extend(
+                [
+                    "speaker_projection",
+                    "speaker_norm",
+                    "speaker_classifier",
+                ]
+            )
+        if not self.enable_pronunciation_error or self.pron_error_head is None:
+            prefixes.append("pron_error_head")
+        return prefixes
+
+    def load_state_dict(self, state_dict, strict=True):
+        if any(key.startswith("module.") for key in state_dict.keys()):
+            state_dict = state_dict.__class__(
+                (key.replace("module.", "", 1), value)
+                for key, value in state_dict.items()
+            )
+
+        optional_prefixes = list(self._optional_state_prefixes())
+        optional_prefixes_set = set(optional_prefixes)
+
+        def _has_prefix(prefix: str) -> bool:
+            return any(key.startswith(prefix) for key in state_dict.keys())
+
+        needs_ctc_sharing_remap = (
+            not self.enable_ctc_seq2seq_sharing
+            and self.ctc_linear is not None
+            and not any(key.startswith("ctc_linear.") for key in state_dict.keys())
+            and (
+                _has_prefix("ctc_state_projector.")
+                or _has_prefix("ctc_classifier.")
+                or _has_prefix("ctc_seq2seq_adapter.")
+            )
+        )
+
+        remapped = state_dict.__class__()
+        for key, value in state_dict.items():
+            if key.startswith("module."):
+                key = key.replace("module.", "", 1)
+
+            if needs_ctc_sharing_remap and key.startswith("ctc_linear."):
+                continue
+
+            if key.startswith("ctc_linear.") and self.ctc_linear is None:
+                continue
+
+            if key.startswith("encoder_layers."):
+                remapped[key] = value
+                continue
+
+            if key.startswith("cnns."):
+                segments = key.split(".")
+                if len(segments) >= 3:
+                    layer_idx = segments[1]
+                    stage_idx = segments[2]
+                    remainder = segments[3:]
+                    new_segments = ["encoder_layers", layer_idx]
+                    if stage_idx == "0":
+                        new_segments.append("block")
+                        new_segments.extend(remainder)
+                    elif stage_idx == "1":
+                        new_segments.append("post_norm")
+                        new_segments.extend(remainder)
+                    else:
+                        new_segments.extend(segments[2:])
+                    key = ".".join(new_segments)
+            remapped[key] = value
+
+        filtered_state = remapped
+
+        if needs_ctc_sharing_remap:
+            for src, dst in (
+                ("ctc_state_projector.linear_layer.", "ctc_linear.0."),
+                ("ctc_classifier.linear_layer.", "ctc_linear.2."),
+            ):
+                weight_key = src + "weight"
+                bias_key = src + "bias"
+                if weight_key in filtered_state:
+                    filtered_state[dst + "weight"] = filtered_state[weight_key]
+                if bias_key in filtered_state:
+                    filtered_state[dst + "bias"] = filtered_state[bias_key]
+
+        for prefix in optional_prefixes:
+            if not _has_prefix(prefix + "."):
+                continue
+            if prefix not in optional_prefixes_set:
+                continue
+            optional_prefixes_set.remove(prefix)
+
+        return super().load_state_dict(filtered_state, strict=strict)
 
     def get_feature(self, x):
-        x = self.to_mfcc(x.squeeze(1))
+        x = self.to_mfcc(x)
         x = self.init_cnn(x)
-        x = self.cnns(x)
+        for layer in self.encoder_layers:
+            x = layer(x)
         x = self.projection(x)
         return x
 
     def length_to_mask(self, lengths):
-        mask = torch.arange(lengths.max()).unsqueeze(0).expand(lengths.shape[0], -1).type_as(lengths)
-        mask = torch.gt(mask+1, lengths.unsqueeze(1)).to(lengths.device)
+        mask = (
+            torch.arange(lengths.max(), device=lengths.device)
+            .unsqueeze(0)
+            .expand(lengths.shape[0], -1)
+            .type_as(lengths)
+        )
+        mask = torch.gt(mask + 1, lengths.unsqueeze(1))
         return mask
 
     def get_future_mask(self, out_length, unmask_future_steps=0):
@@ -70,13 +738,17 @@ class ASRCNN(nn.Module):
         mask = torch.gt(index_tensor, index_tensor.T + unmask_future_steps)
         return mask
 
+
 class ASRS2S(nn.Module):
-    def __init__(self,
-                 embedding_dim=256,
-                 hidden_dim=512,
-                 n_location_filters=32,
-                 location_kernel_size=63,
-                 n_token=40):
+    def __init__(
+        self,
+        embedding_dim=256,
+        hidden_dim=512,
+        n_location_filters=32,
+        location_kernel_size=63,
+        n_token=40,
+        attention_dropout=0.0,
+    ):
         super(ASRS2S, self).__init__()
         self.embedding = nn.Embedding(n_token, embedding_dim)
         val_range = math.sqrt(6 / hidden_dim)
@@ -89,12 +761,16 @@ class ASRS2S(nn.Module):
             hidden_dim,
             hidden_dim,
             n_location_filters,
-            location_kernel_size
+            location_kernel_size,
+            attention_dropout=attention_dropout,
         )
-        self.decoder_rnn = nn.LSTMCell(self.decoder_rnn_dim + embedding_dim, self.decoder_rnn_dim)
+        self.decoder_rnn = nn.LSTMCell(
+            self.decoder_rnn_dim + embedding_dim, self.decoder_rnn_dim
+        )
         self.project_to_hidden = nn.Sequential(
             LinearNorm(self.decoder_rnn_dim * 2, hidden_dim),
-            nn.Tanh())
+            nn.Tanh(),
+        )
         self.sos = 1
         self.eos = 2
 
@@ -122,13 +798,23 @@ class ASRS2S(nn.Module):
         """
         self.initialize_decoder_states(memory, memory_mask)
         # text random mask
-        random_mask = (torch.rand(text_input.shape) < self.random_mask).to(text_input.device)
-        _text_input = text_input.clone()
-        _text_input.masked_fill_(random_mask, self.unk_index)
-        decoder_inputs = self.embedding(_text_input).transpose(0, 1) # -> [T, B, channel]
+        if self.training and self.random_mask > 0:
+            random_mask = (
+                torch.rand(text_input.shape, device=text_input.device) < self.random_mask
+            )
+            _text_input = text_input.clone()
+            _text_input.masked_fill_(random_mask, self.unk_index)
+        else:
+            _text_input = text_input
+        decoder_inputs = self.embedding(_text_input).transpose(0, 1)  # -> [T, B, channel]
         start_embedding = self.embedding(
-            torch.LongTensor([self.sos]*decoder_inputs.size(1)).to(decoder_inputs.device))
-        decoder_inputs = torch.cat((start_embedding.unsqueeze(0), decoder_inputs), dim=0)
+            torch.LongTensor([self.sos] * decoder_inputs.size(1)).to(
+                decoder_inputs.device
+            )
+        )
+        decoder_inputs = torch.cat(
+            (start_embedding.unsqueeze(0), decoder_inputs), dim=0
+        )
 
         hidden_outputs, logit_outputs, alignments = [], [], []
         while len(hidden_outputs) < decoder_inputs.size(0):
@@ -139,37 +825,43 @@ class ASRS2S(nn.Module):
             logit_outputs += [logit]
             alignments += [attention_weights]
 
-        hidden_outputs, logit_outputs, alignments = \
-            self.parse_decoder_outputs(
-                hidden_outputs, logit_outputs, alignments)
+        hidden_outputs, logit_outputs, alignments = self.parse_decoder_outputs(
+            hidden_outputs, logit_outputs, alignments
+        )
 
         return hidden_outputs, logit_outputs, alignments
-
 
     def decode(self, decoder_input):
 
         cell_input = torch.cat((decoder_input, self.attention_context), -1)
         self.decoder_hidden, self.decoder_cell = self.decoder_rnn(
-            cell_input,
-            (self.decoder_hidden, self.decoder_cell))
+            cell_input, (self.decoder_hidden, self.decoder_cell)
+        )
 
         attention_weights_cat = torch.cat(
-            (self.attention_weights.unsqueeze(1),
-            self.attention_weights_cum.unsqueeze(1)),dim=1)
+            (
+                self.attention_weights.unsqueeze(1),
+                self.attention_weights_cum.unsqueeze(1),
+            ),
+            dim=1,
+        )
 
         self.attention_context, self.attention_weights = self.attention_layer(
             self.decoder_hidden,
             self.memory,
             self.processed_memory,
             attention_weights_cat,
-            self.mask)
+            self.mask,
+        )
 
         self.attention_weights_cum += self.attention_weights
 
-        hidden_and_context = torch.cat((self.decoder_hidden, self.attention_context), -1)
+        hidden_and_context = torch.cat(
+            (self.decoder_hidden, self.attention_context), -1
+        )
         hidden = self.project_to_hidden(hidden_and_context)
 
-        # dropout to increasing g
+        # dropout to increasing generalization gap
         logit = self.project_to_n_symbols(F.dropout(hidden, 0.5, self.training))
 
         return hidden, logit, self.attention_weights
@@ -177,7 +869,7 @@ class ASRS2S(nn.Module):
     def parse_decoder_outputs(self, hidden, logit, alignments):
 
         # -> [B, T_out + 1, max_time]
-        alignments = torch.stack(alignments).transpose(0,1)
+        alignments = torch.stack(alignments).transpose(0, 1)
         # [T_out + 1, B, n_symbols] -> [B, T_out + 1,  n_symbols]
         logit = torch.stack(logit).transpose(0, 1).contiguous()
         hidden = torch.stack(hidden).transpose(0, 1).contiguous()

--- a/Utils/JDC/model.py
+++ b/Utils/JDC/model.py
@@ -1,50 +1,165 @@
-"""
-Implementation of model from:
-Kum et al. - "Joint Detection and Classification of Singing Voice Melody Using
-Convolutional Recurrent Neural Networks" (2019)
-Link: https://www.semanticscholar.org/paper/Joint-Detection-and-Classification-of-Singing-Voice-Kum-Nam/60a2ad4c7db43bace75805054603747fcd062c0d
-"""
+import math
+from typing import Dict, Optional
+
 import torch
 from torch import nn
-        
-class JDCNet(nn.Module):
-    """
-    Joint Detection and Classification Network model for singing voice melody.
-    """
+
+
+class SinusoidalPositionalEncoding(nn.Module):
+    """Sinusoidal positional encoding compatible with batch-first inputs."""
+
+    def __init__(self, d_model: int, max_len: int = 2000):
+        super().__init__()
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.register_buffer("pe", pe)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        seq_len = x.size(1)
+        return x + self.pe[:, :seq_len]
+
+
+class SequenceModel(nn.Module):
+    """Flexible temporal modeling block supporting BiLSTM and Transformer backends."""
+
+    def __init__(
+        self,
+        input_size: int,
+        model_type: str = "bilstm",
+        hidden_size: int = 384,
+        num_layers: int = 2,
+        dropout: float = 0.3,
+        bidirectional: bool = True,
+        nhead: int = 8,
+        dim_feedforward: int = 1024,
+        max_len: int = 2000,
+    ):
+        super().__init__()
+        self.model_type = model_type.lower()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.bidirectional = bidirectional
+        self.num_layers = num_layers
+
+        if self.model_type == "bilstm":
+            lstm_dropout = dropout if num_layers > 1 else 0.0
+            self.model = nn.LSTM(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                dropout=lstm_dropout,
+                batch_first=True,
+                bidirectional=bidirectional,
+            )
+            self._output_dim = hidden_size * (2 if bidirectional else 1)
+        elif self.model_type == "transformer":
+            self.pos_encoding = SinusoidalPositionalEncoding(input_size, max_len=max_len)
+            encoder_layer = nn.TransformerEncoderLayer(
+                d_model=input_size,
+                nhead=nhead,
+                dim_feedforward=dim_feedforward,
+                dropout=dropout,
+                batch_first=True,
+                activation="gelu",
+            )
+            self.model = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+            self.layer_norm = nn.LayerNorm(input_size)
+            self._output_dim = input_size
+        else:
+            raise ValueError(f"Unsupported sequence model type: {model_type}")
+
+    @property
+    def output_dim(self) -> int:
+        return self._output_dim
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.model_type == "bilstm":
+            x, _ = self.model(x)
+            return x
+        if self.model_type == "transformer":
+            x = self.layer_norm(self.pos_encoding(x))
+            return self.model(x)
+        raise RuntimeError("Invalid sequence model configuration")
+
+
+class ResBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, leaky_relu_slope=0.01):
+        super().__init__()
+        self.downsample = in_channels != out_channels
+
+        self.pre_conv = nn.Sequential(
+            nn.BatchNorm2d(num_features=in_channels),
+            nn.LeakyReLU(leaky_relu_slope, inplace=True),
+            nn.MaxPool2d(kernel_size=(1, 2)),
+        )
+
+        self.conv = nn.Sequential(
+            nn.Conv2d(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                kernel_size=3,
+                padding=1,
+                bias=False,
+            ),
+            nn.BatchNorm2d(out_channels),
+            nn.LeakyReLU(leaky_relu_slope, inplace=True),
+            nn.Conv2d(out_channels, out_channels, 3, padding=1, bias=False),
+        )
+
+        self.conv1by1 = None
+        if self.downsample:
+            self.conv1by1 = nn.Conv2d(in_channels, out_channels, 1, bias=False)
+
+    def forward(self, x):
+        x = self.pre_conv(x)
+        if self.downsample:
+            x = self.conv(x) + self.conv1by1(x)
+        else:
+            x = self.conv(x) + x
+        return x
+
+
+class LegacyJDCNet(nn.Module):
+    """Original JDCNet architecture used by legacy checkpoints."""
+
     def __init__(self, num_class=722, seq_len=31, leaky_relu_slope=0.01):
         super().__init__()
         self.num_class = num_class
 
-        # input = (b, 1, 31, 513), b = batch size
         self.conv_block = nn.Sequential(
-            nn.Conv2d(in_channels=1, out_channels=64, kernel_size=3, padding=1, bias=False),  # out: (b, 64, 31, 513)
+            nn.Conv2d(
+                in_channels=1,
+                out_channels=64,
+                kernel_size=3,
+                padding=1,
+                bias=False,
+            ),
             nn.BatchNorm2d(num_features=64),
             nn.LeakyReLU(leaky_relu_slope, inplace=True),
-            nn.Conv2d(64, 64, 3, padding=1, bias=False),  # (b, 64, 31, 513)
+            nn.Conv2d(64, 64, 3, padding=1, bias=False),
         )
 
-        # res blocks
-        self.res_block1 = ResBlock(in_channels=64, out_channels=128)  # (b, 128, 31, 128)
-        self.res_block2 = ResBlock(in_channels=128, out_channels=192)  # (b, 192, 31, 32)
-        self.res_block3 = ResBlock(in_channels=192, out_channels=256)  # (b, 256, 31, 8)
+        self.res_block1 = ResBlock(in_channels=64, out_channels=128)
+        self.res_block2 = ResBlock(in_channels=128, out_channels=192)
+        self.res_block3 = ResBlock(in_channels=192, out_channels=256)
 
-        # pool block
         self.pool_block = nn.Sequential(
             nn.BatchNorm2d(num_features=256),
             nn.LeakyReLU(leaky_relu_slope, inplace=True),
-            nn.MaxPool2d(kernel_size=(1, 4)),  # (b, 256, 31, 2)
+            nn.MaxPool2d(kernel_size=(1, 4)),
             nn.Dropout(p=0.2),
         )
 
-        # maxpool layers (for auxiliary network inputs)
-        # in = (b, 128, 31, 513) from conv_block, out = (b, 128, 31, 2)
         self.maxpool1 = nn.MaxPool2d(kernel_size=(1, 40))
-        # in = (b, 128, 31, 128) from res_block1, out = (b, 128, 31, 2)
         self.maxpool2 = nn.MaxPool2d(kernel_size=(1, 20))
-        # in = (b, 128, 31, 32) from res_block2, out = (b, 128, 31, 2)
         self.maxpool3 = nn.MaxPool2d(kernel_size=(1, 10))
 
-        # in = (b, 640, 31, 2), out = (b, 256, 31, 2)
         self.detector_conv = nn.Sequential(
             nn.Conv2d(640, 256, 1, bias=False),
             nn.BatchNorm2d(256),
@@ -52,87 +167,24 @@ class JDCNet(nn.Module):
             nn.Dropout(p=0.2),
         )
 
-        # input: (b, 31, 512) - resized from (b, 256, 31, 2)
         self.bilstm_classifier = nn.LSTM(
-            input_size=512, hidden_size=256,
-            batch_first=True, bidirectional=True)  # (b, 31, 512)
+            input_size=512,
+            hidden_size=256,
+            batch_first=True,
+            bidirectional=True,
+        )
 
-        # input: (b, 31, 512) - resized from (b, 256, 31, 2)
         self.bilstm_detector = nn.LSTM(
-            input_size=512, hidden_size=256,
-            batch_first=True, bidirectional=True)  # (b, 31, 512)
+            input_size=512,
+            hidden_size=256,
+            batch_first=True,
+            bidirectional=True,
+        )
 
-        # input: (b * 31, 512)
-        self.classifier = nn.Linear(in_features=512, out_features=self.num_class)  # (b * 31, num_class)
+        self.classifier = nn.Linear(in_features=512, out_features=self.num_class)
+        self.detector = nn.Linear(in_features=512, out_features=2)
 
-        # input: (b * 31, 512)
-        self.detector = nn.Linear(in_features=512, out_features=2)  # (b * 31, 2) - binary classifier
-
-        # initialize weights
         self.apply(self.init_weights)
-
-    def get_feature_GAN(self, x):
-        x = x.float().transpose(-1, -2)
-        
-        convblock_out = self.conv_block(x)
-        
-        resblock1_out = self.res_block1(convblock_out)
-        resblock2_out = self.res_block2(resblock1_out)
-        resblock3_out = self.res_block3(resblock2_out)
-        poolblock_out = self.pool_block[0](resblock3_out)
-        poolblock_out = self.pool_block[1](poolblock_out)
-        
-        return poolblock_out.transpose(-1, -2)
-        
-    def get_feature(self, x):
-        x = x.float().transpose(-1, -2)
-        
-        convblock_out = self.conv_block(x)
-        
-        resblock1_out = self.res_block1(convblock_out)
-        resblock2_out = self.res_block2(resblock1_out)
-        resblock3_out = self.res_block3(resblock2_out)
-        poolblock_out = self.pool_block[0](resblock3_out)
-        poolblock_out = self.pool_block[1](poolblock_out)
-        
-        return self.pool_block[2](poolblock_out)
-        
-    def forward(self, x):
-        """
-        Returns:
-            classification_prediction, detection_prediction
-            sizes: (b, 31, 722), (b, 31, 2)
-        """
-        ###############################
-        # forward pass for classifier #
-        ###############################
-        seq_len = x.shape[-1]
-        x = x.float().transpose(-1, -2)
-        
-        convblock_out = self.conv_block(x)
-        
-        resblock1_out = self.res_block1(convblock_out)
-        resblock2_out = self.res_block2(resblock1_out)
-        resblock3_out = self.res_block3(resblock2_out)
-        
-        
-        poolblock_out = self.pool_block[0](resblock3_out)
-        poolblock_out = self.pool_block[1](poolblock_out)
-        GAN_feature = poolblock_out.transpose(-1, -2)
-        poolblock_out = self.pool_block[2](poolblock_out)
-        
-        # (b, 256, 31, 2) => (b, 31, 256, 2) => (b, 31, 512)
-        classifier_out = poolblock_out.permute(0, 2, 1, 3).contiguous().view((-1, seq_len, 512))
-        classifier_out, _ = self.bilstm_classifier(classifier_out)  # ignore the hidden states
-
-        classifier_out = classifier_out.contiguous().view((-1, 512))  # (b * 31, 512)
-        classifier_out = self.classifier(classifier_out)
-        classifier_out = classifier_out.view((-1, seq_len, self.num_class))  # (b, 31, num_class)
-        
-        # sizes: (b, 31, 722), (b, 31, 2)
-        # classifier output consists of predicted pitch classes per frame
-        # detector output consists of: (isvoice, notvoice) estimates per frame
-        return torch.abs(classifier_out.squeeze()), GAN_feature, poolblock_out
 
     @staticmethod
     def init_weights(m):
@@ -151,38 +203,229 @@ class JDCNet(nn.Module):
                     nn.init.orthogonal_(p.data)
                 else:
                     nn.init.normal_(p.data)
-                    
-
-class ResBlock(nn.Module):
-    def __init__(self, in_channels: int, out_channels: int, leaky_relu_slope=0.01):
-        super().__init__()
-        self.downsample = in_channels != out_channels
-
-        # BN / LReLU / MaxPool layer before the conv layer - see Figure 1b in the paper
-        self.pre_conv = nn.Sequential(
-            nn.BatchNorm2d(num_features=in_channels),
-            nn.LeakyReLU(leaky_relu_slope, inplace=True),
-            nn.MaxPool2d(kernel_size=(1, 2)),  # apply downsampling on the y axis only
-        )
-
-        # conv layers
-        self.conv = nn.Sequential(
-            nn.Conv2d(in_channels=in_channels, out_channels=out_channels,
-                      kernel_size=3, padding=1, bias=False),
-            nn.BatchNorm2d(out_channels),
-            nn.LeakyReLU(leaky_relu_slope, inplace=True),
-            nn.Conv2d(out_channels, out_channels, 3, padding=1, bias=False),
-        )
-
-        # 1 x 1 convolution layer to match the feature dimensions
-        self.conv1by1 = None
-        if self.downsample:
-            self.conv1by1 = nn.Conv2d(in_channels, out_channels, 1, bias=False)
 
     def forward(self, x):
-        x = self.pre_conv(x)
-        if self.downsample:
-            x = self.conv(x) + self.conv1by1(x)
+        seq_len = x.shape[-1]
+        x = x.float().transpose(-1, -2)
+
+        convblock_out = self.conv_block(x)
+
+        resblock1_out = self.res_block1(convblock_out)
+        resblock2_out = self.res_block2(resblock1_out)
+        resblock3_out = self.res_block3(resblock2_out)
+
+        poolblock_out = self.pool_block[0](resblock3_out)
+        poolblock_out = self.pool_block[1](poolblock_out)
+        gan_feature = poolblock_out.transpose(-1, -2)
+        poolblock_out = self.pool_block[2](poolblock_out)
+
+        classifier_out = (
+            poolblock_out.permute(0, 2, 1, 3).contiguous().view((-1, seq_len, 512))
+        )
+        classifier_out, _ = self.bilstm_classifier(classifier_out)
+        classifier_out = classifier_out.contiguous().view((-1, 512))
+        classifier_out = self.classifier(classifier_out)
+        classifier_out = classifier_out.view((-1, seq_len, self.num_class))
+
+        mp1_out = self.maxpool1(convblock_out)
+        mp2_out = self.maxpool2(resblock1_out)
+        mp3_out = self.maxpool3(resblock2_out)
+
+        concat_out = torch.cat((mp1_out, mp2_out, mp3_out, poolblock_out), dim=1)
+        detector_out = self.detector_conv(concat_out)
+
+        detector_out = (
+            detector_out.permute(0, 2, 1, 3).contiguous().view((-1, seq_len, 512))
+        )
+        detector_out, _ = self.bilstm_detector(detector_out)
+        detector_out = detector_out.contiguous().view((-1, 512))
+        detector_out = self.detector(detector_out)
+        detector_out = detector_out.view((-1, seq_len, 2)).sum(axis=-1)
+
+        f0 = classifier_out
+        if f0.dim() >= 3 and f0.shape[-1] == 1:
+            f0 = f0.squeeze(-1)
+        f0 = torch.abs(f0)
+        return f0, detector_out, poolblock_out
+
+
+class ModernJDCNet(nn.Module):
+    """Updated JDCNet architecture matching the modern training code."""
+
+    def __init__(
+        self,
+        num_class=1,
+        leaky_relu_slope=0.01,
+        sequence_model_config: Optional[Dict] = None,
+        head_dropout: float = 0.2,
+    ):
+        super().__init__()
+        self.num_class = num_class
+        sequence_model_config = sequence_model_config or {}
+        head_dropout = max(0.1, min(0.3, float(head_dropout)))
+        self.classifier_dropout = nn.Dropout(p=head_dropout)
+        self.detector_dropout = nn.Dropout(p=head_dropout)
+
+        self.conv_block = nn.Sequential(
+            nn.Conv2d(
+                in_channels=1,
+                out_channels=64,
+                kernel_size=3,
+                padding=1,
+                bias=False,
+            ),
+            nn.BatchNorm2d(num_features=64),
+            nn.LeakyReLU(leaky_relu_slope, inplace=True),
+            nn.Conv2d(64, 64, 3, padding=1, bias=False),
+        )
+
+        self.res_block1 = ResBlock(in_channels=64, out_channels=128)
+        self.res_block2 = ResBlock(in_channels=128, out_channels=192)
+        self.res_block3 = ResBlock(in_channels=192, out_channels=256)
+
+        self.pool_block = nn.Sequential(
+            nn.BatchNorm2d(num_features=256),
+            nn.LeakyReLU(leaky_relu_slope, inplace=True),
+            nn.MaxPool2d(kernel_size=(1, 4)),
+            nn.Dropout(p=0.5),
+        )
+
+        self.maxpool1 = nn.MaxPool2d(kernel_size=(1, 40))
+        self.maxpool2 = nn.MaxPool2d(kernel_size=(1, 20))
+        self.maxpool3 = nn.MaxPool2d(kernel_size=(1, 10))
+
+        self.detector_conv = nn.Sequential(
+            nn.Conv2d(640, 256, 1, bias=False),
+            nn.BatchNorm2d(256),
+            nn.LeakyReLU(leaky_relu_slope, inplace=True),
+            nn.Dropout(p=0.5),
+        )
+
+        sequence_model_config = dict(sequence_model_config)
+        sequence_model_config.setdefault("input_size", 512)
+        classifier_config = dict(sequence_model_config)
+        detector_config = dict(sequence_model_config)
+        self.sequence_classifier = SequenceModel(**classifier_config)
+        self.sequence_detector = SequenceModel(**detector_config)
+
+        classifier_dim = self.sequence_classifier.output_dim
+        detector_dim = self.sequence_detector.output_dim
+
+        self.classifier = nn.Linear(in_features=classifier_dim, out_features=self.num_class)
+        self.detector = nn.Linear(in_features=detector_dim, out_features=2)
+
+        self.apply(self.init_weights)
+
+    @staticmethod
+    def init_weights(m):
+        if isinstance(m, nn.Linear):
+            nn.init.kaiming_uniform_(m.weight)
+            if m.bias is not None:
+                nn.init.constant_(m.bias, 0)
+        elif isinstance(m, nn.Conv2d):
+            nn.init.xavier_normal_(m.weight)
+        elif isinstance(m, nn.LSTM) or isinstance(m, nn.LSTMCell):
+            for p in m.parameters():
+                if p.data is None:
+                    continue
+
+                if len(p.shape) >= 2:
+                    nn.init.orthogonal_(p.data)
+                else:
+                    nn.init.normal_(p.data)
+
+    def forward(self, x):
+        seq_len = x.shape[-1]
+
+        convblock_out = self.conv_block(x)
+
+        resblock1_out = self.res_block1(convblock_out)
+        resblock2_out = self.res_block2(resblock1_out)
+        resblock3_out = self.res_block3(resblock2_out)
+        poolblock_out = self.pool_block(resblock3_out)
+
+        classifier_out = (
+            poolblock_out.permute(0, 2, 1, 3).contiguous().view((-1, seq_len, 512))
+        )
+        classifier_out = self.sequence_classifier(classifier_out)
+        classifier_out = self.classifier_dropout(classifier_out)
+        classifier_out = classifier_out.contiguous().view((-1, classifier_out.shape[-1]))
+        classifier_out = self.classifier(classifier_out)
+        classifier_out = classifier_out.view((-1, seq_len, self.num_class))
+
+        mp1_out = self.maxpool1(convblock_out)
+        mp2_out = self.maxpool2(resblock1_out)
+        mp3_out = self.maxpool3(resblock2_out)
+        concat_out = torch.cat((mp1_out, mp2_out, mp3_out, poolblock_out), dim=1)
+        detector_out = self.detector_conv(concat_out)
+
+        detector_out = (
+            detector_out.permute(0, 2, 1, 3).contiguous().view((-1, seq_len, 512))
+        )
+        detector_out = self.sequence_detector(detector_out)
+        detector_out = self.detector_dropout(detector_out)
+        detector_out = detector_out.contiguous().view((-1, detector_out.shape[-1]))
+        detector_out = self.detector(detector_out)
+        detector_out = detector_out.view((-1, seq_len, 2)).sum(axis=-1)
+
+        f0 = classifier_out
+        if f0.dim() >= 3 and f0.shape[-1] == 1:
+            f0 = f0.squeeze(-1)
+        f0 = torch.abs(f0)
+        return f0, detector_out, poolblock_out
+
+
+def detect_jdc_variant(state_dict: Dict[str, torch.Tensor]) -> str:
+    """Detect whether a checkpoint corresponds to the legacy or modern JDCNet."""
+
+    keys = [key.replace("module.", "", 1) for key in state_dict.keys()]
+    if any(key.startswith("bilstm_classifier.") for key in keys):
+        return "legacy"
+    return "modern"
+
+
+def build_jdc_model(
+    model_params: Optional[Dict] = None,
+    state_dict: Optional[Dict[str, torch.Tensor]] = None,
+) -> nn.Module:
+    model_params = dict(model_params or {})
+    variant = None
+    if state_dict is not None:
+        variant = detect_jdc_variant(state_dict)
+    if variant == "legacy":
+        num_class = model_params.get("num_class")
+        if not isinstance(num_class, int) or num_class <= 0:
+            weight = state_dict.get("classifier.weight") if state_dict else None
+            if isinstance(weight, torch.Tensor):
+                num_class = int(weight.shape[0])
+            else:
+                num_class = 1
+        seq_len = model_params.get("seq_len", 31)
+        return LegacyJDCNet(num_class=num_class, seq_len=seq_len)
+
+    sequence_model_config = model_params.get("sequence_model", {})
+    num_class = model_params.get("num_class")
+    if not isinstance(num_class, int) or num_class <= 0:
+        weight = None
+        if state_dict is not None:
+            weight = state_dict.get("classifier.weight")
+        if isinstance(weight, torch.Tensor):
+            num_class = int(weight.shape[0])
         else:
-            x = self.conv(x) + x
-        return x
+            num_class = 1
+    return ModernJDCNet(
+        num_class=num_class,
+        sequence_model_config=sequence_model_config,
+        head_dropout=model_params.get("head_dropout", 0.2),
+    )
+
+
+JDCNet = ModernJDCNet
+
+__all__ = [
+    "JDCNet",
+    "LegacyJDCNet",
+    "ModernJDCNet",
+    "build_jdc_model",
+    "detect_jdc_variant",
+]

--- a/train_finetune_accelerate.py
+++ b/train_finetune_accelerate.py
@@ -15,7 +15,14 @@ from monotonic_align import mask_from_lens
 from meldataset import build_dataloader
 from Utils.PLBERT.util import load_plbert
 from models import build_model, load_ASR_models, load_checkpoint, load_F0_models
-from utils import get_data_path_list, length_to_mask, log_norm, maximum_path, recursive_munch
+from utils import (
+    get_data_path_list,
+    length_to_mask,
+    log_norm,
+    maximum_path,
+    parse_asr_outputs,
+    recursive_munch,
+)
 from losses import DiscriminatorLoss, GeneratorLoss, MultiResolutionSTFTLoss, WavLMLoss
 from Modules.slmadv import SLMAdversarialLoss
 from Modules.diffusion.sampler import DiffusionSampler, ADPM2Sampler, KarrasSchedule
@@ -108,7 +115,8 @@ def main(config_path):
     
     # load pretrained F0 model
     F0_path = config.get('F0_path', False)
-    pitch_extractor = load_F0_models(F0_path)
+    F0_config = config.get('F0_config', None)
+    pitch_extractor = load_F0_models(F0_path, F0_config)
     
     # load PL-BERT model
     BERT_path = config.get('PLBERT_dir', False)
@@ -263,7 +271,8 @@ def main(config_path):
                     ref = torch.cat([ref_ss, ref_sp], dim=1)
                 
             try:
-                ppgs, s2s_pred, s2s_attn = model.text_aligner(mels, mask, texts)
+                asr_outputs = model.text_aligner(mels, mask, texts)
+                ppgs, s2s_pred, s2s_attn = parse_asr_outputs(asr_outputs)
                 s2s_attn = s2s_attn.transpose(-1, -2)
                 s2s_attn = s2s_attn[..., 1:]
                 s2s_attn = s2s_attn.transpose(-1, -2)
@@ -569,7 +578,8 @@ def main(config_path):
                         mask = length_to_mask(mel_input_length // (2 ** n_down)).to('cuda')
                         text_mask = length_to_mask(input_lengths).to(texts.device)
 
-                        _, _, s2s_attn = model.text_aligner(mels, mask, texts)
+                        asr_outputs = model.text_aligner(mels, mask, texts)
+                        _, _, s2s_attn = parse_asr_outputs(asr_outputs)
                         s2s_attn = s2s_attn.transpose(-1, -2)
                         s2s_attn = s2s_attn[..., 1:]
                         s2s_attn = s2s_attn.transpose(-1, -2)

--- a/train_second.py
+++ b/train_second.py
@@ -2,7 +2,14 @@ from torch.utils.tensorboard import SummaryWriter
 from meldataset import build_dataloader
 from Utils.PLBERT.util import load_plbert
 from models import build_model, load_ASR_models, load_checkpoint, load_F0_models
-from utils import get_data_path_list, length_to_mask, log_norm, maximum_path, recursive_munch
+from utils import (
+    get_data_path_list,
+    length_to_mask,
+    log_norm,
+    maximum_path,
+    parse_asr_outputs,
+    recursive_munch,
+)
 from losses import DiscriminatorLoss, GeneratorLoss, MultiResolutionSTFTLoss, WavLMLoss
 from Modules.slmadv import SLMAdversarialLoss
 from Modules.diffusion.sampler import DiffusionSampler, ADPM2Sampler, KarrasSchedule
@@ -106,7 +113,8 @@ def main(config_path):
     
     # load pretrained F0 model
     F0_path = config.get('F0_path', False)
-    pitch_extractor = load_F0_models(F0_path)
+    F0_config = config.get('F0_config', None)
+    pitch_extractor = load_F0_models(F0_path, F0_config)
     
     # load PL-BERT model
     BERT_path = config.get('PLBERT_dir', False)
@@ -255,7 +263,8 @@ def main(config_path):
                 text_mask = length_to_mask(input_lengths).to(texts.device)
 
                 try:
-                    _, _, s2s_attn = model.text_aligner(mels, mask, texts)
+                    asr_outputs = model.text_aligner(mels, mask, texts)
+                    _, _, s2s_attn = parse_asr_outputs(asr_outputs)
                     s2s_attn = s2s_attn.transpose(-1, -2)
                     s2s_attn = s2s_attn[..., 1:]
                     s2s_attn = s2s_attn.transpose(-1, -2)
@@ -561,7 +570,8 @@ def main(config_path):
                         mask = length_to_mask(mel_input_length // (2 ** n_down)).to('cuda')
                         text_mask = length_to_mask(input_lengths).to(texts.device)
 
-                        _, _, s2s_attn = model.text_aligner(mels, mask, texts)
+                        asr_outputs = model.text_aligner(mels, mask, texts)
+                        _, _, s2s_attn = parse_asr_outputs(asr_outputs)
                         s2s_attn = s2s_attn.transpose(-1, -2)
                         s2s_attn = s2s_attn[..., 1:]
                         s2s_attn = s2s_attn.transpose(-1, -2)


### PR DESCRIPTION
## Summary
- replace the bundled auxiliary ASR implementation with the latest architecture that supports gradient checkpointing, multi-task heads, and updated loading behaviour
- add modern JDC pitch extractor support alongside legacy compatibility and allow specifying an auxiliary F0 config in training recipes
- update training utilities to normalise ASR outputs and forward optional F0 configs when bootstrapping auxiliary models

## Testing
- python -m compileall Utils models.py train_first.py train_second.py train_finetune.py train_finetune_accelerate.py

------
https://chatgpt.com/codex/tasks/task_e_68e97ce6fbf48332abf38ef25cd017a1