### PR TITLE
Fix WavLM call signature

### DIFF
--- a/losses.py
+++ b/losses.py
@@ -230,7 +230,11 @@ class WavLMLoss(torch.nn.Module):
         context = nullcontext() if require_grad else torch.no_grad()
         with context:
             if self.slm_type == "wavlm":
-                outputs = self.slm(input_values=audio_16, output_hidden_states=True)
+                # Some WavLM checkpoints (e.g. torchaudio implementations) expect
+                # the waveform as the first positional argument instead of the
+                # HuggingFace-style ``input_values`` keyword. Passing the tensor
+                # positionally keeps compatibility with both variants.
+                outputs = self.slm(audio_16, output_hidden_states=True)
                 hidden_states = outputs.hidden_states
             else:
                 features = self.feature_extractor(audio_16, sampling_rate=self.slm_sr)["input_features"]


### PR DESCRIPTION
## Summary
- call the WavLM speaker loss model with positional audio input instead of the `input_values` keyword to support implementations that do not accept keyword arguments
- document the reason for the change inline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eb8a3affc88332bbeda9bfa9d60f05