### PR TITLE
Enable accelerate-based DDP for second-stage training

### DIFF
--- a/Modules/slmadv.py
+++ b/Modules/slmadv.py
@@ -2,6 +2,12 @@ import torch
 import numpy as np
 import torch.nn.functional as F
 
+
+class SkipSLMAdversarialLoss(RuntimeError):
+    """Signal that the current batch should skip SLM adversarial training."""
+
+    pass
+
 class SLMAdversarialLoss(torch.nn.Module):
 
     def __init__(self, model, wl, sampler, min_len, max_len, batch_percentage=0.5, skip_update=10, sig=1.5):
@@ -122,7 +128,7 @@ class SLMAdversarialLoss(torch.nn.Module):
                 break
 
         if len(sp) <= 1:
-            return None
+            raise SkipSLMAdversarialLoss("Insufficient valid samples for SLM adversarial loss")
             
         sp = torch.stack(sp)
         wav = torch.stack(wav).float()


### PR DESCRIPTION
## Summary
- integrate the accelerate `Accelerator` workflow into `train_second.py`, including distributed-safe logging, dataloader setup, and optimizer preparation
- add robust handling for SLM adversarial training with global skip detection and separation of generator/discriminator steps
- raise a dedicated `SkipSLMAdversarialLoss` exception when insufficient samples are available to avoid DDP gradient readiness issues

## Testing
- python -m compileall train_second.py
- python -m compileall Modules/slmadv.py

------
https://chatgpt.com/codex/tasks/task_e_68efdd524a188332b9e71998029569f6