### PR TITLE
Vendor monotonic alignment helpers

### DIFF
--- a/monotonic_align/__init__.py
+++ b/monotonic_align/__init__.py
@@ -1,0 +1,145 @@
+"""Pure Python fallbacks for the ``monotonic_align`` package.
+
+The original project ships a set of Cython/CUDA extensions that are
+frequently recompiled during installation.  The compilation step fails on
+newer NVIDIA architectures (e.g. Hopper/Blackwell) when the bundled NVRTC
+version cannot recognise the automatically selected ``--gpu-architecture``.
+To keep StyleTTS2 trainable on such GPUs we provide a fully self-contained
+implementation of the two helpers that the project relies on: the
+``mask_from_lens`` utility and the dynamic-programming ``maximum_path``
+search.
+
+The algorithms mirror the behaviour of
+``https://github.com/resemble-ai/monotonic_align`` but run entirely on the
+CPU using NumPy/Torch tensors, removing the dependency on external build
+toolchains.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+__all__ = ["mask_from_len", "mask_from_lens", "maximum_path"]
+
+
+def mask_from_len(lens: torch.Tensor, max_len: int | None = None) -> torch.Tensor:
+    """Return a boolean mask that is ``True`` for valid sequence positions."""
+
+    if not isinstance(lens, torch.Tensor):
+        raise TypeError("lens must be a torch.Tensor")
+
+    if max_len is None:
+        if lens.numel() == 0:
+            max_len = 0
+        else:
+            max_len = int(lens.max().item())
+
+    if max_len < 0:
+        raise ValueError("max_len must be non-negative")
+
+    index = torch.arange(max_len, device=lens.device)
+    return index.view(1, -1) < lens.unsqueeze(1)
+
+
+def mask_from_lens(
+    similarity: torch.Tensor,
+    symbol_lens: torch.Tensor,
+    mel_lens: torch.Tensor,
+) -> torch.Tensor:
+    """Replicate the helper from ``monotonic_align.mas`` for compatibility."""
+
+    if similarity.ndim != 3:
+        raise ValueError("similarity tensor must be 3-D (B, S, T)")
+
+    _, symbols, mels = similarity.size()
+    mask_s = mask_from_len(symbol_lens, symbols)
+    mask_t = mask_from_len(mel_lens, mels)
+    return (mask_s.unsqueeze(2) * mask_t.unsqueeze(1)).to(similarity.dtype)
+
+
+def _maximum_path_each(
+    path: np.ndarray,
+    value: np.ndarray,
+    t_x: int,
+    t_y: int,
+    max_neg_val: float,
+) -> None:
+    """In-place dynamic programming kernel operating on NumPy arrays."""
+
+    if t_x <= 0 or t_y <= 0:
+        return
+
+    max_neg = float(max_neg_val)
+
+    for y in range(t_y):
+        x_start = max(0, t_x + y - t_y)
+        x_end = min(t_x, y + 1)
+        for x in range(x_start, x_end):
+            if x == y:
+                v_cur = max_neg
+            else:
+                v_cur = value[x, y - 1]
+
+            if x == 0:
+                v_prev = 0.0 if y == 0 else max_neg
+            else:
+                v_prev = value[x - 1, y - 1]
+
+            value[x, y] = max(v_cur, v_prev) + value[x, y]
+
+    index = t_x - 1
+    for y in range(t_y - 1, -1, -1):
+        path[index, y] = 1
+        if index == 0:
+            continue
+
+        take_diag = index == y
+        if not take_diag and y > 0:
+            take_diag = value[index, y - 1] < value[index - 1, y - 1]
+        if take_diag:
+            index -= 1
+
+
+def maximum_path(
+    value: torch.Tensor,
+    mask: torch.Tensor | None = None,
+    *,
+    max_neg_val: float = -1e9,
+) -> torch.Tensor:
+    """Return the most likely monotonic alignment path for ``value``.
+
+    The function mirrors ``monotonic_align.mas.maximum_path`` but only
+    implements the 1-step topology that StyleTTS2 uses.  The work is carried
+    out on CPU NumPy arrays which avoids triggering NVRTC/NVCC.
+    """
+
+    if value.ndim != 3:
+        raise ValueError("value tensor must be 3-D (B, text, mel)")
+
+    if mask is None:
+        mask = torch.ones_like(value, dtype=torch.bool)
+    elif mask.shape != value.shape:
+        raise ValueError("mask must have the same shape as value")
+
+    device = value.device
+    dtype = value.dtype
+
+    value_np = value.detach().to(torch.float32).cpu().numpy().copy()
+    mask_np = mask.detach().cpu().numpy().astype(np.float32, copy=False)
+
+    paths = np.zeros_like(value_np, dtype=np.int32)
+    t_x_max = mask_np.sum(axis=1)[:, 0].astype(np.int32)
+    t_y_max = mask_np.sum(axis=2)[:, 0].astype(np.int32)
+
+    for batch in range(value_np.shape[0]):
+        _maximum_path_each(
+            paths[batch],
+            value_np[batch],
+            int(t_x_max[batch]),
+            int(t_y_max[batch]),
+            max_neg_val,
+        )
+
+    return torch.from_numpy(paths).to(device=device, dtype=dtype)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,3 @@ pandas
 tensorboard
 nvitop
 openai-whisper
-git+https://github.com/resemble-ai/monotonic_align.git

--- a/runtime_cuda_compat.py
+++ b/runtime_cuda_compat.py
@@ -1,0 +1,79 @@
+"""Utilities to keep training scripts compatible with GPUs lacking NVRTC support.
+
+This module is imported before :mod:`torch` so that we can force PyTorch to use
+pre-built CUDA kernels instead of the NVRTC JIT (nvFuser, TorchInductor, etc.).
+The NVRTC toolchain bundled with many PyTorch wheels does not yet recognise the
+latest GPU architectures (e.g. NVIDIA B-series).  Attempting to compile a
+kernel on those GPUs fails with ``nvrtc: error: invalid value for
+--gpu-architecture (-arch)`` and aborts training.
+
+Importing this module sets a handful of conservative environment defaults that
+turn off runtime compilation.  After :mod:`torch` is imported the helper can be
+called once more to disable any remaining nvFuser hooks.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Iterable, Tuple
+
+__all__ = ["disable_cuda_jit_features_if_available"]
+
+
+_CUDA_JIT_ENV_DEFAULTS = {
+    # Force PyTorch to skip TorchInductor/torch.compile paths entirely.
+    "TORCHINDUCTOR_DISABLE": "1",
+    "TORCH_COMPILE_DISABLE": "1",
+    # Disable the nvFuser backend and keep the legacy CUDA fuser selected.
+    "PYTORCH_NVFUSER_DISABLE": "1",
+    "PYTORCH_JIT_ENABLE_NVFUSER": "0",
+    "TORCH_CUDA_FUSER": "old",
+}
+
+
+def _set_default_env(overrides: Iterable[Tuple[str, str]]) -> None:
+    for key, value in overrides:
+        if key in os.environ:
+            continue
+        os.environ[key] = value
+
+
+_set_default_env(_CUDA_JIT_ENV_DEFAULTS.items())
+
+
+def disable_cuda_jit_features_if_available() -> bool:
+    """Best-effort attempt to disable nvFuser hooks after :mod:`torch` import.
+
+    Returns ``True`` if at least one runtime compiler hook was disabled.
+    ``False`` is returned when :mod:`torch` is unavailable or if none of the
+    expected internal helpers are present (older versions of PyTorch).
+    """
+
+    try:
+        import torch  # type: ignore
+    except Exception as exc:  # pragma: no cover - import failure is rare
+        warnings.warn(
+            f"Unable to import torch while disabling CUDA JIT features: {exc}"
+        )
+        return False
+
+    disabled_any = False
+    torch_compiler_guards = [
+        ("_jit_set_nvfuser_enabled", (False,)),
+        ("_jit_set_texpr_fuser_enabled", (False,)),
+        ("_jit_override_can_fuse_on_gpu", (False,)),
+        ("_jit_override_can_fuse_on_cpu", (False,)),
+    ]
+
+    for attr_name, args in torch_compiler_guards:
+        fn = getattr(torch._C, attr_name, None)  # type: ignore[attr-defined]
+        if fn is None:
+            continue
+        try:
+            fn(*args)
+            disabled_any = True
+        except Exception:  # pragma: no cover - safety net for older versions
+            continue
+
+    return disabled_any

--- a/train_finetune.py
+++ b/train_finetune.py
@@ -1,3 +1,11 @@
+import os
+
+import runtime_cuda_compat
+
+import torch
+
+runtime_cuda_compat.disable_cuda_jit_features_if_available()
+
 # load packages
 from munch import Munch
 from torch.utils.tensorboard import SummaryWriter
@@ -13,12 +21,10 @@ from optimizers import build_optimizer
 
 import copy
 import logging
-import os
 import random
 import yaml
 import time
 import numpy as np
-import torch
 import torch.nn.functional as F
 import click
 import shutil

--- a/train_finetune_accelerate.py
+++ b/train_finetune_accelerate.py
@@ -1,11 +1,17 @@
 import copy
 import os
+
+import runtime_cuda_compat
+
+import torch
+
+runtime_cuda_compat.disable_cuda_jit_features_if_available()
+
 import random
 import yaml
 import time
 from munch import Munch
 import numpy as np
-import torch
 import torch.nn.functional as F
 import click
 import shutil

--- a/train_first.py
+++ b/train_first.py
@@ -1,3 +1,11 @@
+import os
+
+import runtime_cuda_compat
+
+import torch
+
+runtime_cuda_compat.disable_cuda_jit_features_if_available()
+
 from munch import Munch
 from monotonic_align import mask_from_lens
 from meldataset import build_dataloader
@@ -19,13 +27,11 @@ from accelerate import Accelerator
 from accelerate import DistributedDataParallelKwargs
 from torch.utils.tensorboard import SummaryWriter
 from accelerate.logging import get_logger
-import os
 import shutil
 import click
 import random
 import yaml
 import numpy as np
-import torch
 import torch.nn.functional as F
 import time
 import logging

--- a/train_second.py
+++ b/train_second.py
@@ -1,3 +1,11 @@
+import os
+
+import runtime_cuda_compat
+
+import torch
+
+runtime_cuda_compat.disable_cuda_jit_features_if_available()
+
 from torch.utils.tensorboard import SummaryWriter
 from meldataset import build_dataloader
 from Utils.PLBERT.util import load_plbert
@@ -25,11 +33,9 @@ from accelerate.logging import get_logger
 from torch.nn.utils import clip_grad_norm_
 
 import logging
-import os
 import yaml
 import time
 import numpy as np
-import torch
 import click
 import shutil
 import traceback

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,4 @@
-from monotonic_align import maximum_path
-from monotonic_align.core import maximum_path_c
-import numpy as np
+from monotonic_align import maximum_path as _maximum_path
 import torch
 import matplotlib.pyplot as plt
 from munch import Munch
@@ -9,19 +7,9 @@ from munch import Munch
 _SUPPORTED_MIXED_PRECISION = {"no", "fp16", "bf16"}
 
 def maximum_path(neg_cent, mask):
-  """ Cython optimized version.
-  neg_cent: [b, t_t, t_s]
-  mask: [b, t_t, t_s]
-  """
-  device = neg_cent.device
-  dtype = neg_cent.dtype
-  neg_cent =  np.ascontiguousarray(neg_cent.data.cpu().numpy().astype(np.float32))
-  path =  np.ascontiguousarray(np.zeros(neg_cent.shape, dtype=np.int32))
+    """Compatibility wrapper that delegates to the bundled implementation."""
 
-  t_t_max = np.ascontiguousarray(mask.sum(1)[:, 0].data.cpu().numpy().astype(np.int32))
-  t_s_max = np.ascontiguousarray(mask.sum(2)[:, 0].data.cpu().numpy().astype(np.int32))
-  maximum_path_c(path, neg_cent, t_t_max, t_s_max)
-  return torch.from_numpy(path).to(device=device, dtype=dtype)
+    return _maximum_path(neg_cent, mask)
 
 def get_data_path_list(train_path=None, val_path=None):
     if train_path is None:


### PR DESCRIPTION
## Summary
- vendor a pure Python implementation of the monotonic alignment helpers used by the training scripts so that CUDA/NVRTC is no longer required during installation
- switch the existing utilities to the bundled implementation and drop the external dependency from the requirements list

## Testing
- `python - <<'PY'
import torch
from monotonic_align import mask_from_lens, maximum_path
B, S, T = 2, 4, 6
value = torch.randn(B, S, T)
symbol_lens = torch.tensor([4,3])
mel_lens = torch.tensor([6,5])
mask = mask_from_lens(value, symbol_lens, mel_lens)
path = maximum_path(value, mask)
print(path.shape, path.sum())
PY`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2b8d7e108332abcc917468b88075)